### PR TITLE
Add temporary ducer implementation

### DIFF
--- a/fill/BUILD
+++ b/fill/BUILD
@@ -2,7 +2,9 @@ cc_library(
     name = "telemetry_reader",
     srcs = ["telemetry_reader.cc"],
     hdrs = ["telemetry_reader.h"],
-    deps = ["//protos:telemetry_cc_proto"],
+    deps = [
+        "//protos:telemetry_cc_proto",
+        "//sensors:sensor"],
 )
 
 cc_test(
@@ -11,6 +13,7 @@ cc_test(
     srcs = ["telemetry_reader_test.cc"],
     deps = [
         ":telemetry_reader",
+        "//sensors:mock_sensor",
         "@googletest//:gtest_main",
     ],
 )
@@ -22,6 +25,7 @@ cc_binary(
         ":telemetry_reader",
         "//protos:command_cc_grpc",
         "//protos:telemetry_cc_grpc",
+        "//sensors:ducer",
         "@abseil-cpp//absl/flags:flag",
         "@abseil-cpp//absl/flags:parse",
         "@abseil-cpp//absl/strings:str_format",

--- a/fill/fill_station.cc
+++ b/fill/fill_station.cc
@@ -6,6 +6,7 @@
 #include <thread>
 
 #include "telemetry_reader.h"
+#include "sensors/ducer.h"
 
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
@@ -83,12 +84,12 @@ class FillStationClient
 {
 public:
     FillStationClient(std::shared_ptr<Channel> channel)
-        : stub_(Telemeter::NewStub(channel)) {}
+        : stub_(Telemeter::NewStub(channel)), ducer_(std::make_shared<Ducer>()) {}
 
     // TODO(Zach) add telemetry parameters
     bool SendTelemetry(const std::string &temp)
     {
-        TelemetryReader reader;
+        TelemetryReader reader(*ducer_);
         Telemetry telem = reader.read();
 
         // Container for the Ack
@@ -117,6 +118,7 @@ public:
 
 private:
     std::unique_ptr<Telemeter::Stub> stub_;
+    std::shared_ptr<Sensor> ducer_;
 };
 
 /*

--- a/fill/telemetry_reader.cc
+++ b/fill/telemetry_reader.cc
@@ -5,6 +5,6 @@ using telemetry::Telemetry;
 Telemetry TelemetryReader::read() {
     Telemetry telem;
     // TODO(Zach) add telemetry parameters
-    telem.set_temp("It works!");
+    telem.set_temp(sensor_.Read());
     return telem;
 }

--- a/fill/telemetry_reader.h
+++ b/fill/telemetry_reader.h
@@ -1,8 +1,16 @@
+#ifndef FILL_TELEMETRY_READER_H_
+#define FILL_TELEMETRY_READER_H_
+
 #include "protos/telemetry.pb.h"
+#include "sensors/sensor.h"
 
 using telemetry::Telemetry;
 
 class TelemetryReader {
- public:
+  public:
+    TelemetryReader(Sensor& sensor) : sensor_(sensor) {}
     Telemetry read();
+  private:
+    Sensor& sensor_;
 };
+#endif

--- a/fill/telemetry_reader_test.cc
+++ b/fill/telemetry_reader_test.cc
@@ -1,13 +1,20 @@
 #include "telemetry_reader.h"
+#include "sensors/mock_sensor.h"
 
-#include "gtest/gtest.h"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 namespace {
 
+using ::testing::Return;
+
 TEST(TelemetryReaderTest, BasicTest) {
-    TelemetryReader reader;
+    float test_val = 3.14;
+    MockSensor sensor;
+    EXPECT_CALL(sensor, Read()).Times(1).WillOnce(Return(test_val));
+    TelemetryReader reader(sensor);
     Telemetry telem = reader.read();
-    EXPECT_EQ(telem.temp(), "It works!");
+    EXPECT_EQ(telem.temp(), test_val);
 }
 
 } //namespace

--- a/protos/telemetry.proto
+++ b/protos/telemetry.proto
@@ -17,7 +17,7 @@ service Telemeter {
 // The telemetry message
 // TODO(Zach) add telemetry values
 message Telemetry {
-    string temp = 1;
+    float temp = 1;
 }
 
 // The response message containing an ack

--- a/sensors/BUILD
+++ b/sensors/BUILD
@@ -1,0 +1,33 @@
+cc_library(
+    name = "sensor",
+    hdrs = ["sensor.h"],
+    deps = [],
+    visibility = [
+        "//fill:__subpackages__",
+        "//ground:__subpackages__",
+        ],
+)
+
+cc_library(
+    name = "ducer",
+    srcs = ["ducer.cc"],
+    hdrs = ["ducer.h"],
+    deps = [":sensor"],
+    visibility = [
+        "//fill:__subpackages__",
+        "//ground:__subpackages__",
+        ],
+)
+
+cc_library(
+    name = "mock_sensor",
+    hdrs = ["mock_sensor.h"],
+    deps = [
+        ":sensor", 
+        "@googletest//:gtest_main",
+        ],
+    visibility = [
+        "//fill:__subpackages__",
+        "//ground:__subpackages__",
+        ],
+)

--- a/sensors/ducer.cc
+++ b/sensors/ducer.cc
@@ -1,0 +1,7 @@
+#include "ducer.h"
+
+float Ducer::Read() {
+  float reading = 3.14;
+  cache_.push_back(reading);
+  return reading;
+}

--- a/sensors/ducer.h
+++ b/sensors/ducer.h
@@ -1,0 +1,6 @@
+#include "sensor.h"
+
+class Ducer : public Sensor {
+ public:
+  float Read();
+};

--- a/sensors/mock_sensor.h
+++ b/sensors/mock_sensor.h
@@ -1,0 +1,12 @@
+#ifndef SENSORS_MOCK_SENSOR_H_
+#define SENSORS_MOCK_SENSOR_H_
+
+#include "sensor.h"
+
+#include <gmock/gmock.h>  // Brings in gMock.
+
+class MockSensor : public Sensor {
+ public:
+  MOCK_METHOD(float, Read, (), (override));
+};
+#endif

--- a/sensors/sensor.h
+++ b/sensors/sensor.h
@@ -1,0 +1,14 @@
+#ifndef SENSORS_SENSOR_H_
+#define SENSORS_SENSOR_H_
+
+#include <vector>
+
+class Sensor {
+  public:
+  virtual ~Sensor() {}
+    virtual float Read() = 0;
+  protected:
+    // cache for rolling averages
+    std::vector<float> cache_;
+};
+#endif


### PR DESCRIPTION
 This is mostly to provide an example of testing with gMocks, and providing an early template for future sensor integration.
 
 Changes:
 - create sensor class
 - create mock sensor for testing
 - update telemetry reader test
 - create ducer class
 - update telem proto to have float field
 - add ducer member var to fill_station